### PR TITLE
Novos atalhos (Suporte remoto, Limpar notificações) ✨

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ Qualquer sugestão de melhoria ou novas funcionalidades abra um PR. Lembrando qu
 <kbd>Ctrl</kbd><kbd>I</kbd> (No navegador) → Com link (`Markdown`) de uma imagem selecionado, gera o código `Html` com bordas e centralizado
 
 ### Geral
-<kbd>Win</kbd><kbd>A</kbd> → Edita esse projeto no VSCode  
+<kbd>Win</kbd><kbd>H</kbd> → Edita esse projeto no VSCode  
 <kbd>Win</kbd><kbd>F1</kbd> → Abre a base [Todos os links](https://simix.movidesk.com/kb/pt-br/article/60634/todos-links)  
 <kbd>Win</kbd><kbd>F2</kbd> → Abre essa página  
 <kbd>Win</kbd><kbd>C</kbd> → Executa o cmd como adminitrador  
 <kbd>Win</kbd><kbd>S</kbd> → Vai direto para a última mensagem/pesquisa do slack  
 <kbd>Win</kbd><kbd>Espaço</kbd> → Abre/volta o foco para o Notepad++  
 <kbd>Win</kbd><kbd>Enter</kbd> → Executa o texto selecionado  
-<kbd>Win</kbd><kbd>A</kbd> → Abre esse projeto no VS Code  
+<kbd>Win</kbd><kbd>T</kbd> → Copia o id selecionado e abre o TeamViewer e AnyDesk  
+<kbd>Win</kbd><kbd>Esc</kbd> → Limpa as notificações do Windows  
 <kbd>F12</kbd><kbd>A</kbd> → Recarrega o script  
 
 ## Hotstrings

--- a/Scripts/AHK.ahk
+++ b/Scripts/AHK.ahk
@@ -10,7 +10,7 @@ SaveReload() {
 }
 
 ; Edit AHK VS Code project
-#a::Run, %A_ScriptDir%\Simix.AHK.code-workspace
+#h::Run, %A_ScriptDir%\Simix.AHK.code-workspace
 
 ; Reload
 CapsLock & r::

--- a/Scripts/Shortcuts.ahk
+++ b/Scripts/Shortcuts.ahk
@@ -71,3 +71,18 @@ return
     Send ^v
     return
 #If
+
+; TeamViewer/AnyDesk
+#t::
+    CopyToClipboard()
+    Run, "C:\Program Files (x86)\AnyDesk\AnyDesk.exe"
+    Run, "C:\Program Files (x86)\TeamViewer\TeamViewer.exe"
+return
+
+; Clear Windows notifications
+#Esc::
+    Send, #a
+    Sleep, 200
+    Send, {Tab}{Tab}{Tab}{Tab}{Tab}
+    Send, {Space}{Esc}
+return


### PR DESCRIPTION
## Objetivo

Novos atalhos.

## Alterações
- Alterado o editar projeto de <kbd>Win</kbd><kbd>A</kbd> para <kbd>Win</kbd><kbd>H</kbd> de modo a evitar conflitos. ♻
- <kbd>Win</kbd><kbd>T</kbd>: Copia o id selecionado e abre o TeamViewer e AnyDesk. ✨
- <kbd>Win</kbd><kbd>Esc</kbd> Limpa as notificações do Windows. Ex: Slack, rede, dropbox, email... Fecha inclusive as notificações mais safadas, que não tem o X, e ficam sequestrando a tela, sem necessidade. ✨